### PR TITLE
Decimal year/MJD2000 and time dependent model interpolation.

### DIFF
--- a/eoxmagmod/eoxmagmod/__init__.py
+++ b/eoxmagmod/eoxmagmod/__init__.py
@@ -133,7 +133,7 @@ __all__ = [
     'trace_field_line',
 ]
 
-__version__ = '0.8.0'
+__version__ = '0.8.1'
 __author__ = 'Martin Paces (martin.paces@eox.at)'
 __copyright__ = 'Copyright (C) 2014 EOX IT Services GmbH'
 __licence__ = 'EOX licence (MIT style)'

--- a/eoxmagmod/eoxmagmod/__init__.py
+++ b/eoxmagmod/eoxmagmod/__init__.py
@@ -32,7 +32,7 @@ from .util import (
     vrotate,
     vincdecnorm,
 )
-from ._pytimeconv import (
+from .time_util import (
     decimal_year_to_mjd2000,
     mjd2000_to_decimal_year,
     mjd2000_to_year_fraction,

--- a/eoxmagmod/eoxmagmod/include/time_conversion.h
+++ b/eoxmagmod/eoxmagmod/include/time_conversion.h
@@ -159,9 +159,14 @@ static double mjd2k_to_year_fraction(double mjd2k) {
  */
 
 static double decimal_year_to_mjd2k(double decimal_year) {
-    const double whole_year = floor(decimal_year);
-    const int year = (int)whole_year;
-    return mjd2k_year_start(year) + (decimal_year - whole_year)*days_per_year(year);
+    if (isfinite(decimal_year)) {
+        const double whole_year = floor(decimal_year);
+        const int year = (int)whole_year;
+        printf("year = %d; whole_year = %g \n", year, whole_year);
+        return mjd2k_year_start(year) + (decimal_year - whole_year)*days_per_year(year);
+    } else {
+        return decimal_year;
+    }
 }
 
 #endif /* TIME_CONVERSION */

--- a/eoxmagmod/eoxmagmod/include/time_conversion.h
+++ b/eoxmagmod/eoxmagmod/include/time_conversion.h
@@ -162,7 +162,6 @@ static double decimal_year_to_mjd2k(double decimal_year) {
     if (isfinite(decimal_year)) {
         const double whole_year = floor(decimal_year);
         const int year = (int)whole_year;
-        printf("year = %d; whole_year = %g \n", year, whole_year);
         return mjd2k_year_start(year) + (decimal_year - whole_year)*days_per_year(year);
     } else {
         return decimal_year;

--- a/eoxmagmod/eoxmagmod/magnetic_model/coefficients.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/coefficients.py
@@ -79,7 +79,7 @@ class CombinedSHCoefficients(SHCoefficients):
     def __init__(self, *items):
         if len(items) < 1:
             raise ValueError(
-                "The composed model must be composed from at least "
+                "The composed model must be composed from at least one "
                 "coefficient set."
             )
 
@@ -91,7 +91,7 @@ class CombinedSHCoefficients(SHCoefficients):
         for item in items[1:]:
             if is_internal != item.is_internal:
                 raise ValueError(
-                    "Mixing of external and iternal coefficient sets!"
+                    "Mixing of external and internal coefficient sets!"
                 )
             new_start, new_end = item.validity
             validity_start = max(validity_start, new_start)
@@ -139,7 +139,8 @@ class SparseSHCoefficients(SHCoefficients):
         return self._degree
 
     def _subset(self, min_degree, max_degree):
-        """ Get subset of the coefficients for the give min and max degrees. """
+        """ Get subset of the coefficients for the give min. and max. degrees.
+        """
         degree = self._degree
         index = self._index
         coeff = self._coeff

--- a/eoxmagmod/eoxmagmod/magnetic_model/coefficients_mio.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/coefficients_mio.py
@@ -31,7 +31,7 @@ from math import pi
 from numpy import zeros, arange, broadcast_to, sin, cos
 from .coefficients import SparseSHCoefficients, coeff_size
 from ..magnetic_time import mjd2000_to_magnetic_universal_time
-from .._pytimeconv import mjd2000_to_year_fraction
+from ..time_util import mjd2000_to_year_fraction
 
 F_SEASONAL = 2*pi
 F_DIURNAL = 2*pi/24.
@@ -46,12 +46,14 @@ class SparseSHCoefficientsMIO(SparseSHCoefficients):
             is_internal - set False for an external model
     """
 
-    def __init__(self, indices, coefficients, ps_extent, **kwargs):
+    def __init__(self, indices, coefficients, ps_extent,
+                 mjd2000_to_year_fraction=mjd2000_to_year_fraction, **kwargs):
         SparseSHCoefficients.__init__(self, indices, coefficients, **kwargs)
         pmin, pmax, smin, smax = ps_extent
         if pmin > pmax or smin > smax:
             raise Exception("Invalid ps_extent %s!" % ps_extent)
         self.ps_extent = (pmin, pmax, smin, smax)
+        self.mjd2000_to_year_fraction = mjd2000_to_year_fraction
 
     def __call__(self, time, lat_ngp, lon_ngp, lat_sol=None, lon_sol=None,
                  **parameters):
@@ -78,7 +80,7 @@ class SparseSHCoefficientsMIO(SparseSHCoefficients):
         pmin, pmax, smin, smax = self.ps_extent
         n_col = pmax - pmin + 1
         n_row = smax - smin + 1
-        f0_seasonal = F_SEASONAL * mjd2000_to_year_fraction(mjd2000)
+        f0_seasonal = F_SEASONAL * self.mjd2000_to_year_fraction(mjd2000)
         f0_diurnal = F_DIURNAL * mjd2000_to_magnetic_universal_time(
             mjd2000, lat_ngp, lon_ngp, lat_sol, lon_sol,
         )

--- a/eoxmagmod/eoxmagmod/magnetic_model/loader_shc.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/loader_shc.py
@@ -72,6 +72,9 @@ def load_coeff_shc(path, interpolate_in_decimal_years=False, **kwargs):
     }
     options.update(kwargs) # extend or override the default model options
 
+    if not "to_mjd2000" in options:
+        options["to_mjd2000"] = decimal_year_to_mjd2000
+
     times = data["t"]
     if len(times) == 1:
         return SparseSHCoefficientsConstant(
@@ -82,8 +85,6 @@ def load_coeff_shc(path, interpolate_in_decimal_years=False, **kwargs):
             coeff_class = SparseSHCoefficientsTimeDependentDecimalYear
         else:
             coeff_class = SparseSHCoefficientsTimeDependent
-            if not options.get('to_mjd2000'):
-                options["to_mjd2000"] = decimal_year_to_mjd2000
 
         return coeff_class(
             data["nm"], data["gh"], times, **options

--- a/eoxmagmod/eoxmagmod/magnetic_model/tests/coefficient_loaders.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/tests/coefficient_loaders.py
@@ -30,7 +30,7 @@
 from unittest import TestCase, main
 from numpy import inf
 from numpy.testing import assert_allclose
-from eoxmagmod._pytimeconv import decimal_year_to_mjd2000
+from eoxmagmod.time_util import decimal_year_to_mjd2000
 from eoxmagmod.data import (
     CHAOS5_CORE, CHAOS5_CORE_V4, CHAOS5_STATIC,
     CHAOS6_CORE_LATEST, CHAOS6_STATIC,

--- a/eoxmagmod/eoxmagmod/magnetic_model/tests/coefficient_loaders.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/tests/coefficient_loaders.py
@@ -30,7 +30,9 @@
 from unittest import TestCase, main
 from numpy import inf
 from numpy.testing import assert_allclose
-from eoxmagmod.time_util import decimal_year_to_mjd2000
+from eoxmagmod.time_util import (
+    decimal_year_to_mjd2000, decimal_year_to_mjd2000_simple,
+)
 from eoxmagmod.data import (
     CHAOS5_CORE, CHAOS5_CORE_V4, CHAOS5_STATIC,
     CHAOS6_CORE_LATEST, CHAOS6_STATIC,
@@ -139,20 +141,24 @@ class MIOCoefficietLoaderTestMixIn(CoefficietLoaderTestMixIn):
 
 class ShcTestMixIn(CoefficietLoaderTestMixIn):
     path = None
+    kwargs = {}
 
     @classmethod
     def load(cls):
-        return load_coeff_shc(cls.path)
+        return load_coeff_shc(cls.path, **cls.kwargs)
 
 
 class CombinedShcTestMixIn(CoefficietLoaderTestMixIn):
     class_ = CombinedSHCoefficients
     path_core = None
     path_static = None
+    kwargs = {}
 
     @classmethod
     def load(cls):
-        return load_coeff_shc_combined(cls.path_core, cls.path_static)
+        return load_coeff_shc_combined(
+            cls.path_core, cls.path_static, **cls.kwargs
+        )
 
 
 class WmmTestMixIn(CoefficietLoaderTestMixIn):
@@ -168,6 +174,9 @@ class TestCoeffSIFM(TestCase, ShcTestMixIn):
     class_ = SparseSHCoefficientsTimeDependentDecimalYear
     path = SIFM
     degree = 70
+    kwargs = {
+        "interpolate_in_decimal_years": True,
+    }
     validity = decimal_year_to_mjd2000((2013.4976, 2015.4962))
 
 
@@ -175,6 +184,9 @@ class TestCoeffIGRF12(TestCase, ShcTestMixIn):
     class_ = SparseSHCoefficientsTimeDependentDecimalYear
     path = IGRF12
     degree = 13
+    kwargs = {
+        "interpolate_in_decimal_years": True,
+    }
     validity = decimal_year_to_mjd2000((1900.0, 2020.0))
 
 
@@ -190,17 +202,23 @@ class TestCoeffIGRF11(TestCase, CoefficietLoaderTestMixIn):
 #-------------------------------------------------------------------------------
 
 class TestCoeffCHAOS5Core(TestCase, ShcTestMixIn):
-    class_ = SparseSHCoefficientsTimeDependentDecimalYear
+    class_ = SparseSHCoefficientsTimeDependent
     path = CHAOS5_CORE
     degree = 20
-    validity = decimal_year_to_mjd2000((1997.0021, 2015.0007))
+    kwargs = {
+        "to_mjd2000": decimal_year_to_mjd2000_simple
+    }
+    validity = decimal_year_to_mjd2000_simple((1997.0021, 2015.0007))
 
 
 class TestCoeffCHAOS5CoreV4(TestCase, ShcTestMixIn):
-    class_ = SparseSHCoefficientsTimeDependentDecimalYear
+    class_ = SparseSHCoefficientsTimeDependent
     path = CHAOS5_CORE_V4
     degree = 20
-    validity = decimal_year_to_mjd2000((1997.1020, 2016.1027))
+    kwargs = {
+        "to_mjd2000": decimal_year_to_mjd2000_simple
+    }
+    validity = decimal_year_to_mjd2000_simple((1997.1020, 2016.1027))
 
 
 class TestCoeffCHAOS5Static(TestCase, ShcTestMixIn):
@@ -219,7 +237,7 @@ class TestCoeffCHAOS5Combined(TestCase, CombinedShcTestMixIn):
 #-------------------------------------------------------------------------------
 
 class TestCoeffCHAOS6Core(TestCase, ShcTestMixIn):
-    class_ = SparseSHCoefficientsTimeDependentDecimalYear
+    class_ = SparseSHCoefficientsTimeDependent
     path = CHAOS6_CORE_LATEST
     degree = 20
     validity = decimal_year_to_mjd2000((1997.102, 2019.1006))

--- a/eoxmagmod/eoxmagmod/magnetic_model/tests/coefficients_mio.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/tests/coefficients_mio.py
@@ -31,7 +31,7 @@ from unittest import TestCase, main
 from io import open
 from numpy import inf, nan
 from numpy.testing import assert_allclose
-from eoxmagmod._pytimeconv import decimal_year_to_mjd2000
+from eoxmagmod.time_util import decimal_year_to_mjd2000
 from eoxmagmod.magnetic_model.coefficients_mio import SparseSHCoefficientsMIO
 from eoxmagmod.magnetic_model.tests.data import SWARM_MIO_SHA_2_TEST_DATA
 from eoxmagmod.magnetic_model.parser_mio import parse_swarm_mio_file

--- a/eoxmagmod/eoxmagmod/magnetic_model/tests/field_lines.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/tests/field_lines.py
@@ -181,7 +181,7 @@ class TestFieldLineTracing(TestCase):
     @property
     def model(self):
         if not hasattr(self, "_model"):
-            self._model = load_model_shc(IGRF12)
+            self._model = load_model_shc(IGRF12, interpolate_in_decimal_years=True)
         return self._model
 
     def test_trace_field_line_wgs84(self):

--- a/eoxmagmod/eoxmagmod/magnetic_model/tests/model_loaders.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/tests/model_loaders.py
@@ -25,14 +25,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #-------------------------------------------------------------------------------
-# pylint: disable=missing-docstring,no-self-use
+# pylint: disable=missing-docstring,no-self-use,invalid-name
 
 from unittest import TestCase, main
 from itertools import product
 from numpy import nan, inf, isinf, array, empty, full, nditer, asarray
 from numpy.random import uniform
 from numpy.testing import assert_allclose
-from eoxmagmod import decimal_year_to_mjd2000
+from eoxmagmod.time_util import (
+    decimal_year_to_mjd2000, decimal_year_to_mjd2000_simple,
+)
 from eoxmagmod.magnetic_model.loader_shc import (
     load_model_shc, load_model_shc_combined,
 )
@@ -341,7 +343,7 @@ class TestIGRF12(TestCase, SHModelTestMixIn):
     validity = decimal_year_to_mjd2000((1900.0, 2020.0))
 
     def load(self):
-        return load_model_shc(IGRF12)
+        return load_model_shc(IGRF12, interpolate_in_decimal_years=True)
 
 
 class TestSIFM(TestCase, SHModelTestMixIn):
@@ -369,12 +371,14 @@ class TestCHAOS5Static(TestCase, SHModelTestMixIn):
 class TestCHAOS5Core(TestCase, SHModelTestMixIn):
     reference_values = (
         2192.51, (30.0, 40.0, 8000.0),
-        (15126.610410635147, 302.75469100239826, -14477.55985460029)
+        (15126.611217467429, 302.7784261453687, -14477.586706907041)
     )
-    validity = decimal_year_to_mjd2000((1997.0021, 2015.0007))
+    validity = decimal_year_to_mjd2000_simple((1997.0021, 2015.0007))
 
     def load(self):
-        return load_model_shc(CHAOS5_CORE)
+        return load_model_shc(
+            CHAOS5_CORE, to_mjd2000=decimal_year_to_mjd2000_simple,
+        )
 
 
 class TestCHAOS5CoreV4(TestCase, SHModelTestMixIn):
@@ -391,12 +395,15 @@ class TestCHAOS5CoreV4(TestCase, SHModelTestMixIn):
 class TestCHAOS5Combined(TestCase, SHModelTestMixIn):
     reference_values = (
         2411.9, (30.0, 40.0, 8000.0),
-        (15127.018522088763, 313.6359151041108, -14489.200214608843)
+        (15127.018861793757, 313.6542615062537, -14489.218457022034)
     )
-    validity = decimal_year_to_mjd2000((1997.1020, 2016.1027))
+    validity = decimal_year_to_mjd2000_simple((1997.1020, 2016.1027))
 
     def load(self):
-        return load_model_shc_combined(CHAOS5_STATIC, CHAOS5_CORE_V4)
+        return load_model_shc_combined(
+            CHAOS5_STATIC, CHAOS5_CORE_V4,
+            to_mjd2000=decimal_year_to_mjd2000_simple,
+        )
 
 
 class TestCHAOS6Static(TestCase, SHModelTestMixIn):

--- a/eoxmagmod/eoxmagmod/magnetic_model/tests/model_loaders.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/tests/model_loaders.py
@@ -381,6 +381,17 @@ class TestCHAOS5Core(TestCase, SHModelTestMixIn):
         )
 
 
+class TestCHAOS5CoreWithOverridenValidity(TestCHAOS5Core):
+    validity = decimal_year_to_mjd2000_simple((1999.0, 2015.0))
+
+    def load(self):
+        return load_model_shc(
+            CHAOS5_CORE,
+            to_mjd2000=decimal_year_to_mjd2000_simple,
+            validity_start=1999.0, validity_end=2015.0
+        )
+
+
 class TestCHAOS5CoreV4(TestCase, SHModelTestMixIn):
     reference_values = (
         2411.9, (30.0, 40.0, 8000.0),
@@ -406,6 +417,17 @@ class TestCHAOS5Combined(TestCase, SHModelTestMixIn):
         )
 
 
+class TestCHAOS5CombinedOverridenValidity(TestCHAOS5Combined):
+    validity = decimal_year_to_mjd2000_simple((1999.0, 2015.0))
+
+    def load(self):
+        return load_model_shc_combined(
+            CHAOS5_STATIC, CHAOS5_CORE_V4,
+            to_mjd2000=decimal_year_to_mjd2000_simple,
+            validity_start=1999.0, validity_end=2015.0
+        )
+
+
 class TestCHAOS6Static(TestCase, SHModelTestMixIn):
     reference_values = (
         0.0, (30.0, 40.0, 8000.0),
@@ -428,6 +450,17 @@ class TestCHAOS6Core(TestCase, SHModelTestMixIn):
         return load_model_shc(CHAOS6_CORE_LATEST)
 
 
+class TestCHAOS6CoreWithOverridenValidity(TestCHAOS6Core):
+    validity = decimal_year_to_mjd2000((2000.0, 2018.0))
+
+    def load(self):
+        return load_model_shc(
+            CHAOS6_CORE_LATEST,
+            validity_start=2000.0,
+            validity_end=2018.0
+        )
+
+
 class TestCHAOS6Combined(TestCase, SHModelTestMixIn):
     reference_values = (
         2685.9, (30.0, 40.0, 8000.0),
@@ -437,6 +470,16 @@ class TestCHAOS6Combined(TestCase, SHModelTestMixIn):
 
     def load(self):
         return load_model_shc_combined(CHAOS6_CORE_LATEST, CHAOS6_STATIC)
+
+
+class TestCHAOS6CombinedOverridenValidity(TestCHAOS6Combined):
+    validity = decimal_year_to_mjd2000((2000.0, 2018.0))
+
+    def load(self):
+        return load_model_shc_combined(
+            CHAOS6_CORE_LATEST, CHAOS6_STATIC,
+            validity_start=2000.0, validity_end=2018.0
+        )
 
 #-------------------------------------------------------------------------------
 

--- a/eoxmagmod/eoxmagmod/tests/magnetic_time.py
+++ b/eoxmagmod/eoxmagmod/tests/magnetic_time.py
@@ -25,13 +25,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #-------------------------------------------------------------------------------
-# pylint: disable=missing-docstring
+# pylint: disable=missing-docstring, invalid-name
 
 from unittest import TestCase, main
 from numpy import asarray, empty, nditer
 from numpy.random import uniform
 from numpy.testing import assert_allclose
-from eoxmagmod._pytimeconv import decimal_year_to_mjd2000
+from eoxmagmod.time_util import decimal_year_to_mjd2000
 from eoxmagmod.solar_position import sunpos
 from eoxmagmod.dipole_coords import convert_to_dipole
 from eoxmagmod.magnetic_time import mjd2000_to_magnetic_universal_time

--- a/eoxmagmod/eoxmagmod/tests/pytimeconv.py
+++ b/eoxmagmod/eoxmagmod/tests/pytimeconv.py
@@ -28,7 +28,7 @@
 # pylint: disable=missing-docstring, invalid-name, too-few-public-methods
 
 from math import modf, floor
-from numpy import array, vectorize
+from numpy import array, vectorize, inf, nan
 from numpy.random import uniform
 from numpy.testing import assert_allclose
 from unittest import TestCase, main
@@ -93,6 +93,9 @@ class TestMjd2000ToDecimalYear(TestCase):
         self._assert(self.eval([-365.0, 366.0]), [1999.0, 2001])
         self._assert(self.eval([6757.5, 7488.0]), [2018.5, 2020.5])
 
+    def test_mjd2000_to_decimal_year_special_values(self):
+        self._assert(self.eval([-inf, inf, nan]), [-inf, inf, nan])
+
 
 class TestDecimalYearToMjd2000(TestCase):
 
@@ -120,6 +123,9 @@ class TestDecimalYearToMjd2000(TestCase):
         self._assert(self.eval(2000.), 0.0)
         self._assert(self.eval([1999., 2001.0]), [-365., 366.])
         self._assert(self.eval([2018.5, 2020.5]), [6757.5, 7488.0])
+
+    def test_decimal_year_to_mjd2000_special_values(self):
+        self._assert(self.eval([-inf, inf, nan]), [-inf, inf, nan])
 
 #-------------------------------------------------------------------------------
 # reference implementation

--- a/eoxmagmod/eoxmagmod/tests/time_util.py
+++ b/eoxmagmod/eoxmagmod/tests/time_util.py
@@ -1,0 +1,147 @@
+#-------------------------------------------------------------------------------
+#
+#  Time conversion utilities - test
+#
+# Author: Martin Paces <martin.paces@eox.at>
+#
+#-------------------------------------------------------------------------------
+# Copyright (C) 2018 EOX IT Services GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies of this Software or works derived from this Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#-------------------------------------------------------------------------------
+# pylint: disable=missing-docstring, invalid-name, too-few-public-methods
+
+from unittest import TestCase, main
+from numpy import vectorize
+from numpy.random import uniform
+from numpy.testing import assert_allclose
+from eoxmagmod.time_util import (
+    decimal_year_to_mjd2000_simple,
+    mjd2000_to_decimal_year_simple,
+    mjd2000_to_year_fraction_simple,
+)
+
+
+class TestMjd2000ToYearFractionSimple(TestCase):
+
+    @staticmethod
+    def reference(value):
+        return vectorize(_mjd2000_to_year_fraction_simple)(value)
+
+    @staticmethod
+    def eval(value):
+        return mjd2000_to_year_fraction_simple(value)
+
+    @staticmethod
+    def _assert(tested, expected):
+        assert_allclose(tested, expected, rtol=1e-14, atol=1e-11)
+
+    def test_mjd2000_to_year_fraction_far_range(self):
+        values = uniform(-730487., 730485., (100, 100))
+        self._assert(self.eval(values), self.reference(values))
+
+    def test_mjd2000_to_year_fraction_near_range(self):
+        values = uniform(-36524., 36525., (100, 100))
+        self._assert(self.eval(values), self.reference(values))
+
+    def test_mjd2000_to_year_fraction_sanity_check(self):
+        self._assert(self.eval(0.), 0.0)
+        self._assert(self.eval([-365.25, 365.25]), [0.0, 0.0])
+        self._assert(self.eval([6757.125, 7487.625]), [0.5, 0.5])
+
+
+class TestMjd2000ToDecimalYearSimple(TestCase):
+
+    @staticmethod
+    def reference(value):
+        return vectorize(_mjd2000_to_decimal_year_simple)(value)
+
+    @staticmethod
+    def eval(value):
+        return mjd2000_to_decimal_year_simple(value)
+
+    @staticmethod
+    def _assert(tested, expected):
+        assert_allclose(tested, expected, rtol=1e-14, atol=1e-11)
+
+    def test_mjd2000_to_decimal_year_far_range(self):
+        values = uniform(-730487., 730485., (100, 100))
+        self._assert(self.eval(values), self.reference(values))
+
+    def test_mjd2000_to_decimal_year_near_range(self):
+        values = uniform(-36524., 36525., (100, 100))
+        self._assert(self.eval(values), self.reference(values))
+
+    def test_mjd2000_to_decimal_year_sanity_check(self):
+        self._assert(self.eval(0.), 2000.0)
+        self._assert(self.eval([-365.25, 365.25]), [1999.0, 2001])
+        self._assert(self.eval([6757.125, 7487.625]), [2018.5, 2020.5])
+
+
+class TestDecimalYearToMjd2000Simple(TestCase):
+
+    @staticmethod
+    def reference(value):
+        return vectorize(_decimal_year_to_mjd2000_simple)(value)
+
+    @staticmethod
+    def eval(value):
+        return decimal_year_to_mjd2000_simple(value)
+
+    @staticmethod
+    def _assert(tested, expected):
+        assert_allclose(tested, expected, rtol=1e-14, atol=6e-8)
+
+    def test_decimal_year_to_mjd2000_far_range(self):
+        values = uniform(0.0, 4000.0, (100, 100))
+        self._assert(self.eval(values), self.reference(values))
+
+    def test_decimal_year_to_mjd2000_near_range(self):
+        values = uniform(1900, 2100.0, (100, 100))
+        self._assert(self.eval(values), self.reference(values))
+
+    def test_decimal_year_to_mjd2000_sanity_check(self):
+        self._assert(self.eval(2000.), 0.0)
+        self._assert(self.eval([1999., 2001.0]), [-365.25, 365.25])
+        self._assert(self.eval([2018.5, 2020.5]), [6757.125, 7487.625])
+
+#-------------------------------------------------------------------------------
+# reference implementation
+
+def _mjd2000_to_year_fraction_simple(mjd2k):
+    """ Convert Modified Julian Date 2000 to (Julian) year fraction.
+    """
+    return (mjd2k / 365.25) % 1
+
+
+def _mjd2000_to_decimal_year_simple(mjd2k):
+    """ Convert Modified Julian Date 2000 to decimal year.
+    """
+    return 2000.0 + mjd2k / 365.25
+
+
+def _decimal_year_to_mjd2000_simple(decimal_year):
+    """ Covert decimal year to Modified Julian Date 2000.
+    """
+    return (decimal_year - 2000.0) * 365.25
+
+#-------------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    main()

--- a/eoxmagmod/eoxmagmod/tests/time_util.py
+++ b/eoxmagmod/eoxmagmod/tests/time_util.py
@@ -28,7 +28,7 @@
 # pylint: disable=missing-docstring, invalid-name, too-few-public-methods
 
 from unittest import TestCase, main
-from numpy import vectorize
+from numpy import vectorize, inf, nan
 from numpy.random import uniform
 from numpy.testing import assert_allclose
 from eoxmagmod.time_util import (
@@ -93,6 +93,9 @@ class TestMjd2000ToDecimalYearSimple(TestCase):
         self._assert(self.eval([-365.25, 365.25]), [1999.0, 2001])
         self._assert(self.eval([6757.125, 7487.625]), [2018.5, 2020.5])
 
+    def test_mjd2000_to_decimal_year_special_values(self):
+        self._assert(self.eval([-inf, inf, nan]), [-inf, inf, nan])
+
 
 class TestDecimalYearToMjd2000Simple(TestCase):
 
@@ -120,6 +123,9 @@ class TestDecimalYearToMjd2000Simple(TestCase):
         self._assert(self.eval(2000.), 0.0)
         self._assert(self.eval([1999., 2001.0]), [-365.25, 365.25])
         self._assert(self.eval([2018.5, 2020.5]), [6757.125, 7487.625])
+
+    def test_decimal_year_to_mjd2000_special_values(self):
+        self._assert(self.eval([-inf, inf, nan]), [-inf, inf, nan])
 
 #-------------------------------------------------------------------------------
 # reference implementation

--- a/eoxmagmod/eoxmagmod/time_util.py
+++ b/eoxmagmod/eoxmagmod/time_util.py
@@ -1,0 +1,61 @@
+#-------------------------------------------------------------------------------
+#
+#  Time utilities
+#
+# Project: VirES
+# Author: Martin Paces <martin.paces@eox.at>
+#
+#-------------------------------------------------------------------------------
+# Copyright (C) 2018 EOX IT Services GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all
+# copies of this Software or works derived from this Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#-------------------------------------------------------------------------------
+
+from numpy import asarray, floor
+from ._pytimeconv import (
+    decimal_year_to_mjd2000,
+    mjd2000_to_decimal_year,
+    mjd2000_to_year_fraction,
+)
+
+
+def mjd2000_to_decimal_year_simple(mjd2000):
+    """ Convert Modified Julian Date since 2000 to (Julian) decimal year
+    using the simplified conversion method:
+        decimal_year = 2000.0 + mjd2000/365.25
+    """
+    return 2000.0 + asarray(mjd2000) / 365.25
+
+
+def mjd2000_to_year_fraction_simple(mjd2000):
+    """ Convert Modified Julian Date since 2000 to (Julian) year fraction
+    using the simplified conversion method:
+        year_fraction = mjd2000/365.25 - floor(mjd2000/365.25)
+    """
+    mjy2000 = asarray(mjd2000) / 365.25
+    return mjy2000 - floor(mjy2000)
+
+
+def decimal_year_to_mjd2000_simple(decimal_year):
+    """ Convert (Julian) decimal year to Modified Julian Date since 2000
+    using the simplified conversion method:
+        mjd2000 = (decimal_year - 2000.0) * 365.25
+    """
+    return (asarray(decimal_year) - 2000.0) * 365.25

--- a/eoxmagmod/setup.py
+++ b/eoxmagmod/setup.py
@@ -80,7 +80,7 @@ setup(
         'eoxmagmod.magnetic_model.tests.data',
     ],
     license='EOX licence (MIT style)',
-    version='0.8.0',
+    version='0.8.1',
     package_data={
         'eoxmagmod': [
             'data/*',


### PR DESCRIPTION
This PR:
- changes the default SHC format coefficient interpolation from the decimal year to MJD2000 time domain (as agreed with NiO)
- allows optional selection of the coefficient interpolation time domain
- allows optional change of the decimal year / MJD2000 conversion

Integration tests passed without error.