### PR TITLE
production release (VirES v3.12.0)

### DIFF
--- a/eoxmagmod/eoxmagmod/__init__.py
+++ b/eoxmagmod/eoxmagmod/__init__.py
@@ -140,7 +140,7 @@ try:
 except ImportError:
     pass
 
-__version__ = '0.12.0'
+__version__ = '0.12.1'
 __author__ = 'Martin Paces (martin.paces@eox.at)'
 __copyright__ = 'Copyright (C) 2014-2022 EOX IT Services GmbH'
 __licence__ = 'EOX licence (MIT style)'

--- a/eoxmagmod/eoxmagmod/__init__.py
+++ b/eoxmagmod/eoxmagmod/__init__.py
@@ -65,7 +65,7 @@ try:
     from .dipole_coords import (
         get_dipole_rotation_matrix, convert_to_dipole, vrot_from_dipole,
     )
-    from .sheval_dipole import sheval_dipole
+    from .dipole import sheval_dipole
     from .magnetic_time import mjd2000_to_magnetic_universal_time
     from .magnetic_model.loader_shc import load_model_shc, load_model_shc_combined
     from .magnetic_model.loader_igrf import load_model_igrf

--- a/eoxmagmod/eoxmagmod/dipole.py
+++ b/eoxmagmod/eoxmagmod/dipole.py
@@ -33,6 +33,8 @@ from ._pymm import (
 )
 from .dipole_coords import convert_to_dipole, vrot_from_dipole
 
+__all__ = ["sheval_dipole", "rotate_vectors_from_dipole"]
+
 
 def sheval_dipole(arr_in, coef, lat_ngp, lon_ngp,
                   coord_type_in=GEODETIC_ABOVE_WGS84,

--- a/eoxmagmod/eoxmagmod/dipole_coords.py
+++ b/eoxmagmod/eoxmagmod/dipole_coords.py
@@ -33,6 +33,12 @@ from eoxmagmod._pymm import (
     GEOCENTRIC_SPHERICAL, GEOCENTRIC_CARTESIAN,
 )
 
+__all__ = [
+    "get_dipole_rotation_matrix",
+    "convert_to_dipole",
+    "vrot_from_dipole",
+]
+
 DEG2RAD = pi / 180.0
 
 

--- a/eoxmagmod/eoxmagmod/magnetic_model/coefficients.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/coefficients.py
@@ -37,6 +37,16 @@ from .util import (
     coeff_size, convert_value,
 )
 
+__all__ = [
+    "SHCoefficients",
+    "ComposedSHCoefficients",
+    "CombinedSHCoefficients",
+    "SparseSHCoefficients",
+    "SparseSHCoefficientsTimeDependent",
+    "SparseSHCoefficientsConstant",
+    "SparseSHCoefficientsTimeDependentDecimalYear",
+]
+
 
 class SHCoefficients:
     """ Abstract base class for all spherical harmonic coefficients. """

--- a/eoxmagmod/eoxmagmod/magnetic_model/coefficients_mio.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/coefficients_mio.py
@@ -25,16 +25,19 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #-------------------------------------------------------------------------------
-#pylint: disable=no-name-in-module
 
 from math import pi
 from collections import namedtuple
-from numpy import asarray, zeros, arange, broadcast_to, sin, cos
+from numpy import asarray, zeros
 from .coefficients import SparseSHCoefficients, coeff_size
 from ..time_util import (
     mjd2000_to_year_fraction as mjd2000_to_year_fraction_default,
 )
 from .._pymm import fourier2d
+
+__all__ = [
+    "SparseSHCoefficientsMIO",
+]
 
 SCALE_SEASONAL = 2*pi
 SCALE_DIURNAL = 2*pi/24.

--- a/eoxmagmod/eoxmagmod/magnetic_model/field_lines.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/field_lines.py
@@ -30,6 +30,8 @@ from numpy import asarray, copy
 from .._pymm import GEOCENTRIC_CARTESIAN, GEOCENTRIC_SPHERICAL, convert
 from ..util import vnorm, vrotate
 
+__all__ = ["trace_field_line"]
+
 EARTH_RADIUS = 6371.2
 DEFAULT_MIN_RADIUS = 0.9977 * EARTH_RADIUS
 DEFAULT_MAX_RADIUS = 1e6 * EARTH_RADIUS

--- a/eoxmagmod/eoxmagmod/magnetic_model/loader_emm.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/loader_emm.py
@@ -34,6 +34,8 @@ from .coefficients import (
 )
 from .parser_emm import combine_emm_coefficients, parse_emm_file
 
+__all__ = ["load_model_emm", "load_coeff_emm"]
+
 
 def load_model_emm(path_static, path_secvar):
     """ Load model from a EMM coefficient files. """

--- a/eoxmagmod/eoxmagmod/magnetic_model/loader_igrf.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/loader_igrf.py
@@ -30,6 +30,8 @@ from .model import SphericalHarmomicGeomagneticModel
 from .coefficients import SparseSHCoefficientsTimeDependentDecimalYear
 from .parser_igrf import parse_igrf_file
 
+__all__ = ["load_model_igrf", "load_coeff_igrf"]
+
 
 def load_model_igrf(path):
     """ Load model from an IGRF coefficient file.

--- a/eoxmagmod/eoxmagmod/magnetic_model/loader_mio.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/loader_mio.py
@@ -34,6 +34,13 @@ from .model_mio import (
 from .coefficients_mio import SparseSHCoefficientsMIO
 from .parser_mio import parse_swarm_mio_file
 
+__all__ = [
+    "load_model_swarm_mio_internal",
+    "load_model_swarm_mio_external",
+    "load_coeff_swarm_mio_internal",
+    "load_coeff_swarm_mio_external",
+    "convert_external_mio_coeff",
+]
 
 def load_model_swarm_mio_internal(path):
     """ Load internal (secondary field) model from a Swarm MIO_SHA_2* product.

--- a/eoxmagmod/eoxmagmod/magnetic_model/loader_mma.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/loader_mma.py
@@ -42,6 +42,21 @@ from .parser_mma import (
     read_swarm_mma_2f_sm_internal, read_swarm_mma_2f_sm_external,
 )
 
+__all__ = [
+    "load_model_swarm_mma_2c_internal",
+    "load_model_swarm_mma_2c_external",
+    "load_model_swarm_mma_2f_geo_internal",
+    "load_model_swarm_mma_2f_geo_external",
+    "load_model_swarm_mma_2f_sm_internal",
+    "load_model_swarm_mma_2f_sm_external",
+    "load_coeff_swarm_mma_2c_internal",
+    "load_coeff_swarm_mma_2c_external",
+    "load_coeff_swarm_mma_2f_geo_internal",
+    "load_coeff_swarm_mma_2f_geo_external",
+    "load_coeff_swarm_mma_2f_sm_internal",
+    "load_coeff_swarm_mma_2f_sm_external",
+]
+
 # North geomagnetic coordinates used by the MMA products (IGRF-11, 2010.0)
 MMA2C_NGP_LATITUDE = 90 - 9.92   # deg.
 MMA2C_NGP_LONGITUDE = 287.78 - 360.0  # deg.

--- a/eoxmagmod/eoxmagmod/magnetic_model/loader_shc.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/loader_shc.py
@@ -39,16 +39,28 @@ from .coefficients import (
 )
 from .parser_shc import parse_shc_file
 
+__all__ = [
+    "load_model_shc_combined",
+    "load_model_shc",
+    "load_coeff_shc_combined",
+    "load_coeff_shc_composed",
+    "load_coeff_shc",
+]
+
 
 def load_model_shc_combined(*paths, **kwargs):
-    """ Load model with coefficients combined from multiple SHC files. """
+    """ Load model with coefficients combined from multiple SHC files.
+    E.g., combining core and lithospheric models.
+    """
     return SphericalHarmomicGeomagneticModel(
         load_coeff_shc_combined(*paths, **kwargs)
     )
 
 
 def load_model_shc(*paths, **kwargs):
-    """ Load model from an SHC file. """
+    """ Load composed model from one or more SHC files.
+    E.g., composing multiple core models, each with a different time extent.
+    """
     return SphericalHarmomicGeomagneticModel(
         load_coeff_shc_composed(*paths, **kwargs)
     )

--- a/eoxmagmod/eoxmagmod/magnetic_model/loader_wmm.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/loader_wmm.py
@@ -30,6 +30,8 @@ from .model import SphericalHarmomicGeomagneticModel
 from .coefficients import SparseSHCoefficientsTimeDependentDecimalYear
 from .parser_wmm import parse_wmm_file
 
+__all__ = ["load_model_wmm", "load_coeff_wmm"]
+
 
 def load_model_wmm(path):
     """ Load model from a WMM COF file. """

--- a/eoxmagmod/eoxmagmod/magnetic_model/model.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/model.py
@@ -30,13 +30,19 @@
 
 from numpy import asarray, empty, full, nan, nditer
 from .._pymm import GRADIENT, GEOCENTRIC_SPHERICAL, sheval, shevaltemp
-from ..sheval_dipole import rotate_vectors_from_dipole
+from ..dipole import rotate_vectors_from_dipole
 from ..dipole_coords import convert_to_dipole
 from .util import reshape_times_and_coordinates
 from .coefficients import (
     SparseSHCoefficientsTimeDependent,
     CombinedSHCoefficients,
 )
+
+__all__ = [
+    "GeomagneticModel",
+    "SphericalHarmomicGeomagneticModel",
+    "DipoleSphericalHarmomicGeomagneticModel",
+]
 
 
 class GeomagneticModel:

--- a/eoxmagmod/eoxmagmod/magnetic_model/model_composed.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/model_composed.py
@@ -34,6 +34,7 @@ from .._pymm import (
 )
 from .model import GeomagneticModel
 
+__all__ = ["ComposedGeomagneticModel"]
 
 Component = namedtuple("_Component", ["model", "scale", "parameters"])
 

--- a/eoxmagmod/eoxmagmod/magnetic_model/model_mio.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/model_mio.py
@@ -25,7 +25,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 #-------------------------------------------------------------------------------
-# pylint: disable=too-many-arguments,too-many-locals
+# pylint: disable=too-many-arguments
 
 from numpy import nan, asarray, empty, isnan, full
 from .._pymm import GRADIENT, GEOCENTRIC_SPHERICAL, convert, sheval2dfs
@@ -33,6 +33,8 @@ from ..magnetic_time import mjd2000_to_magnetic_universal_time
 from .coefficients_mio import SparseSHCoefficientsMIO
 from .model import GeomagneticModel, DipoleSphericalHarmomicGeomagneticModel
 from .util import reshape_times_and_coordinates, reshape_array, mask_array
+
+__all__ = ["DipoleMIOGeomagneticModel", "MIOPrimaryGeomagneticModel"]
 
 MIO_HEIGHT = 110.0 # km
 MIO_EARTH_RADIUS = 6371.2 # km
@@ -135,6 +137,7 @@ class DipoleMIOGeomagneticModel(DipoleSphericalHarmomicGeomagneticModel):
 
     def __init__(self, coefficients, north_pole, wolf_ratio=MIO_WOLF_RATIO,
                  height=MIO_HEIGHT, earth_radius=MIO_EARTH_RADIUS):
+        del height, earth_radius
 
         if not isinstance(coefficients, SparseSHCoefficientsMIO):
             raise TypeError(

--- a/eoxmagmod/eoxmagmod/magnetic_model/parser_emm.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/parser_emm.py
@@ -29,6 +29,10 @@
 import re
 from numpy import array, stack
 
+__all__ = [
+    "combine_emm_coefficients",
+    "parse_emm_file",
+]
 
 RE_HEADER_LINE = re.compile(r'^-+$')
 EMM_VALIDITY_PERIOD = 5.0 # years

--- a/eoxmagmod/eoxmagmod/magnetic_model/parser_igrf.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/parser_igrf.py
@@ -29,6 +29,8 @@
 
 from numpy import array
 
+__all__ = ["parse_igrf_file"]
+
 IGRF_EXTRAPOLATION_PERIOD = 5.0 # years
 
 

--- a/eoxmagmod/eoxmagmod/magnetic_model/parser_mio.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/parser_mio.py
@@ -29,6 +29,8 @@
 from numpy import array
 from .parser_shc import _strip_shc_comments
 
+__all__ = ["parse_swarm_mio_file"]
+
 
 def parse_swarm_mio_file(file_in):
     """ Parse Swarm MIO_SHA_2* product file format and return a dictionary
@@ -40,6 +42,7 @@ def parse_swarm_mio_file(file_in):
     data["degree_min"] = data["nm"][:, 0].min()
     data["degree_max"] = data["nm"][:, 0].max()
     return data
+
 
 def parse_swarm_mio_coefficients(lines, data):
     """ Parse the Swarm MIO_SHA_2* coefficients. """

--- a/eoxmagmod/eoxmagmod/magnetic_model/parser_mma.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/parser_mma.py
@@ -29,6 +29,15 @@
 from numpy import array
 from spacepy import pycdf
 
+__all__ = [
+    "read_swarm_mma_2c_internal",
+    "read_swarm_mma_2c_external",
+    "read_swarm_mma_2f_geo_internal",
+    "read_swarm_mma_2f_geo_external",
+    "read_swarm_mma_2f_sm_internal",
+    "read_swarm_mma_2f_sm_external",
+]
+
 CDF_EPOCH_TYPE = pycdf.const.CDF_EPOCH.value
 CDF_EPOCH_2000 = 63113904000000.0
 CDF_EPOCH_TO_DAYS = 1.0/86400000.0

--- a/eoxmagmod/eoxmagmod/magnetic_model/parser_shc.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/parser_shc.py
@@ -28,6 +28,8 @@
 
 from numpy import inf, array
 
+__all__ = ["parse_shc_file", "parse_shc_header"]
+
 
 def parse_shc_file(file_in):
     """ Parse SHC file and return a dictionary containing the parsed model data.

--- a/eoxmagmod/eoxmagmod/magnetic_model/parser_wmm.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/parser_wmm.py
@@ -29,6 +29,8 @@
 import re
 from numpy import array
 
+__all__ = ["parse_wmm_file"]
+
 RE_TERMINATING_LINE = re.compile(r'^9+$')
 WMM_VALIDITY_PERIOD = 5.0 # years
 

--- a/eoxmagmod/eoxmagmod/magnetic_model/tests/model_loaders.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/tests/model_loaders.py
@@ -80,7 +80,7 @@ from eoxmagmod._pymm import (
     GEOCENTRIC_CARTESIAN, GEODETIC_ABOVE_WGS84, GEOCENTRIC_SPHERICAL, convert,
     GRADIENT, sheval,
 )
-from eoxmagmod.sheval_dipole import sheval_dipole
+from eoxmagmod.dipole import sheval_dipole
 
 
 class SHModelTestMixIn:

--- a/eoxmagmod/eoxmagmod/magnetic_model/util.py
+++ b/eoxmagmod/eoxmagmod/magnetic_model/util.py
@@ -30,6 +30,17 @@ from bisect import bisect_right
 from numpy import inf
 from numpy.lib.stride_tricks import as_strided
 
+__all__ = [
+    "coeff_size",
+    "convert_value",
+    "parse_file",
+    "reshape_times_and_coordinates",
+    "mask_array",
+    "reshape_array",
+    "get_nonoverlapping_intervals",
+    "aggregate_intersected_intervals",
+]
+
 
 def coeff_size(degree):
     """ Calculate size of the full coefficient array from the given degree. """

--- a/eoxmagmod/eoxmagmod/magnetic_time.py
+++ b/eoxmagmod/eoxmagmod/magnetic_time.py
@@ -30,6 +30,8 @@ from math import pi
 from numpy import sin, cos, arctan2
 from .solar_position import sunpos
 
+__all__ = ["mjd2000_to_magnetic_universal_time"]
+
 DEG2RAD = pi/180.0
 RAD2HOUR = 12.0/pi
 

--- a/eoxmagmod/eoxmagmod/quasi_dipole_coordinates.py
+++ b/eoxmagmod/eoxmagmod/quasi_dipole_coordinates.py
@@ -30,6 +30,13 @@ from os.path import isfile
 from . import _pyqd
 from .data import APEX
 
+__all__ = [
+    "eval_qdlatlon",
+    "eval_qdlatlon_with_base_vectors",
+    "eval_mlt",
+    "eval_subsol",
+]
+
 
 def eval_qdlatlon(gclat, gclon, gcrad, time, fname=APEX):
     """

--- a/eoxmagmod/eoxmagmod/solar_position.py
+++ b/eoxmagmod/eoxmagmod/solar_position.py
@@ -32,6 +32,8 @@
 
 from . import _pysunpos
 
+__all__ = ["sunpos"]
+
 
 def sunpos(time_mjd2k, lat, lon, rad=6371.2, dtt=0):
     """ Calculate solar equatorial and horizontal coordinates

--- a/eoxmagmod/eoxmagmod/tests/dipole.py
+++ b/eoxmagmod/eoxmagmod/tests/dipole.py
@@ -38,7 +38,7 @@ from eoxmagmod._pymm import (
     convert, relradpow, loncossin, legendre, spharpot, sphargrd,
 )
 from eoxmagmod.dipole_coords import convert_to_dipole, vrot_from_dipole
-from eoxmagmod.sheval_dipole import sheval_dipole
+from eoxmagmod.dipole import sheval_dipole
 from eoxmagmod.tests.data import mma_external, mma_internal
 
 

--- a/eoxmagmod/eoxmagmod/tests/time_util.py
+++ b/eoxmagmod/eoxmagmod/tests/time_util.py
@@ -28,14 +28,37 @@
 # pylint: disable=missing-docstring, invalid-name, too-few-public-methods
 
 from unittest import TestCase, main
+from datetime import date, datetime
 from numpy import vectorize, inf, nan
 from numpy.random import uniform
 from numpy.testing import assert_allclose
+from eoxmagmod.tests.util import FunctionTestMixIn
 from eoxmagmod.time_util import (
     decimal_year_to_mjd2000_simple,
     mjd2000_to_decimal_year_simple,
     mjd2000_to_year_fraction_simple,
+    datetime_to_decimal_year,
 )
+
+
+class TestDatetimeToDecimalYear(FunctionTestMixIn, TestCase):
+    NAME = "datetime_to_decimal_year"
+
+    @staticmethod
+    def eval(input_):
+        return datetime_to_decimal_year(input_)
+
+    ACCEPTED = [
+        (datetime(2001, 1, 12), 2001.0301369863014),
+        (datetime(2012, 8, 31), 2012.6639344262296),
+        (datetime(2014, 8, 31), 2014.66301369863),
+        (datetime(2024, 12, 31, 23, 59, 59, 999), 2024.9999999684085),
+    ]
+
+    REJECTED = [
+        (None, TypeError),
+        (date(2001, 1, 12), TypeError),
+    ]
 
 
 class TestMjd2000ToYearFractionSimple(TestCase):

--- a/eoxmagmod/eoxmagmod/tests/util.py
+++ b/eoxmagmod/eoxmagmod/tests/util.py
@@ -28,10 +28,9 @@
 # pylint: disable=missing-docstring
 
 from unittest import main, TestCase
-from datetime import date, datetime
 from numpy import array
 from numpy.testing import assert_allclose
-from eoxmagmod.util import vnorm, vincdecnorm, datetime_to_decimal_year
+from eoxmagmod.util import vnorm, vincdecnorm
 
 
 class FunctionTestMixIn:
@@ -60,26 +59,6 @@ class FunctionTestMixIn:
                 self.assertRaises(expected_exception, self.eval, input_)
             except AssertionError as exc:
                 raise AssertionError(f"\nInput: {input_}\n{exc}") from None
-
-
-class TestDatetimeToDecimalYear(FunctionTestMixIn, TestCase):
-    NAME = "datetime_to_decimal_year"
-
-    @staticmethod
-    def eval(input_):
-        return datetime_to_decimal_year(input_)
-
-    ACCEPTED = [
-        (datetime(2001, 1, 12), 2001.0301369863014),
-        (datetime(2012, 8, 31), 2012.6639344262296),
-        (datetime(2014, 8, 31), 2014.66301369863),
-        (datetime(2024, 12, 31, 23, 59, 59, 999), 2024.9999999684085),
-    ]
-
-    REJECTED = [
-        (None, TypeError),
-        (date(2001, 1, 12), TypeError),
-    ]
 
 
 class TestVnorm(FunctionTestMixIn, TestCase):

--- a/eoxmagmod/eoxmagmod/time_util.py
+++ b/eoxmagmod/eoxmagmod/time_util.py
@@ -28,12 +28,23 @@
 # THE SOFTWARE.
 #-------------------------------------------------------------------------------
 
+from datetime import datetime
 from numpy import asarray, floor
 from ._pytimeconv import (
     decimal_year_to_mjd2000,
     mjd2000_to_decimal_year,
     mjd2000_to_year_fraction,
 )
+
+__all__ = [
+    "decimal_year_to_mjd2000",
+    "mjd2000_to_decimal_year",
+    "mjd2000_to_year_fraction",
+    "mjd2000_to_decimal_year_simple",
+    "mjd2000_to_year_fraction_simple",
+    "decimal_year_to_mjd2000_simple",
+    "datetime_to_decimal_year",
+]
 
 
 def mjd2000_to_decimal_year_simple(mjd2000):
@@ -59,3 +70,19 @@ def decimal_year_to_mjd2000_simple(decimal_year):
         mjd2000 = (decimal_year - 2000.0) * 365.25
     """
     return (asarray(decimal_year) - 2000.0) * 365.25
+
+
+def datetime_to_decimal_year(time):
+    """ Convert time given by a `datetime.datetime` object to a decimal year
+    value.
+    """
+    if not isinstance(time, datetime):
+        raise TypeError("The input must be a datetime object.")
+
+    year_start = datetime(year=time.year, month=1, day=1)
+    next_year_start = datetime(year=time.year+1, month=1, day=1)
+
+    year_elapsed = (time - year_start).total_seconds()
+    year_total = (next_year_start - year_start).total_seconds()
+
+    return time.year + year_elapsed / year_total

--- a/eoxmagmod/eoxmagmod/util.py
+++ b/eoxmagmod/eoxmagmod/util.py
@@ -27,7 +27,6 @@
 #-------------------------------------------------------------------------------
 # pylint: disable=no-name-in-module
 
-from datetime import datetime
 from numpy import sqrt, asarray
 from ._pymm import (
     GEODETIC_ABOVE_WGS84, GEOCENTRIC_SPHERICAL, GEOCENTRIC_CARTESIAN,
@@ -35,6 +34,13 @@ from ._pymm import (
 )
 
 SPHERICAL_COORD_TYPES = (GEODETIC_ABOVE_WGS84, GEOCENTRIC_SPHERICAL)
+
+__all__ = [
+    "vrotate",
+    "vnorm",
+    "vincdecnorm",
+]
+
 
 def vrotate(arr, coord_in, coord_out, coord_type_in, coord_type_out):
     """ Rotate vectors from one coordinate system to another.
@@ -96,19 +102,3 @@ def vincdecnorm(arr):
     """
     tmp = convert(arr, GEOCENTRIC_CARTESIAN, GEOCENTRIC_SPHERICAL)
     return -tmp[..., 0], tmp[..., 1], tmp[..., 2]
-
-
-def datetime_to_decimal_year(time):
-    """ Convert time given by a `datetime.datetime` object to a decimal year
-    value.
-    """
-    if not isinstance(time, datetime):
-        raise TypeError("The input must be a datetime object.")
-
-    year_start = datetime(year=time.year, month=1, day=1)
-    next_year_start = datetime(year=time.year+1, month=1, day=1)
-
-    year_elapsed = (time - year_start).total_seconds()
-    year_total = (next_year_start - year_start).total_seconds()
-
-    return time.year + year_elapsed / year_total

--- a/libcdf/Makefile
+++ b/libcdf/Makefile
@@ -2,11 +2,11 @@
 # install CDF library from sources
 #
 
-VERSION=38_1
+VERSION=39_0
 DIRNAME=./cdf$(VERSION)-dist/
 FILENAME=./cdf$(VERSION)-dist-cdf.tar.gz
 SOURCE_URL=https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/cdf$(VERSION)/linux/cdf$(VERSION)-dist-cdf.tar.gz
-MD5CHECKSUM=279df06ad8672b7111b4cf337de922ea
+MD5CHECKSUM=7c6489017be3aee20d6d99f562f952f6
 INSTALLDIR=/usr/local/cdf
 
 all: build

--- a/libcdf/meta.yaml
+++ b/libcdf/meta.yaml
@@ -8,8 +8,8 @@
 #       are compiled with different versions of the GFortran compiler.
 
 
-{% set version = "3.8.1" %}
-{% set file_version = "cdf38_1" %}
+{% set version = "3.9.0" %}
+{% set file_version = "cdf39_0" %}
 
 package:
   name: "cdf"
@@ -17,7 +17,7 @@ package:
 
 source:
   - url: https://spdf.gsfc.nasa.gov/pub/software/cdf/dist/{{ file_version }}/unix/{{ file_version }}-dist-cdf.tar.gz
-    sha256: 8d8b2d8238516c892c60e60e96272106341b306c09b397094bc8d4192bbcfa64
+    sha256: ae1916d73af43141dc09f14864166395c23245527e79ae92b25314ee0e27a9b7
 
 requirements:
   build:


### PR DESCRIPTION
Key features:
- separating MIO F10.7 scaling from the SH model part (allowing caching of the SH part of the MIO models)
- libcdf upgrade (branch sycn)

related to https://github.com/ESA-VirES/VirES-Server/pull/199